### PR TITLE
Really low priority

### DIFF
--- a/lib/fifo.js
+++ b/lib/fifo.js
@@ -127,7 +127,7 @@ class fifo {
     /* sanity */
     if( !Number.isInteger( options.priority ) ||
         1 > options.priority ||
-        options.priority >= this._fifos.length ) {
+        options.priority > this._fifos.length ) {
       options.priority = 5
     }
 


### PR DESCRIPTION
Array is 0 to 9, but we index options.priority - 1, so we should check for options.priority > this._fifos.length

Issue: #339 in babblesip