### PR TITLE
Check the conditions again on newuac fail

### DIFF
--- a/lib/fifo.js
+++ b/lib/fifo.js
@@ -570,6 +570,8 @@ class fifo {
 
     const newuac = () => {
 
+      if( 0 === this._callcount ) return
+      if( ( this._enterpriseoutboundcalls.size - this._talking ) >= this._callcount ) return /* 2. */
       if( 0 == agents.length ) return
       const agent = agents.shift()
       agent.last = + new Date


### PR DESCRIPTION
If a caller hangs up, "fail" on newuac is triggered which calls newuac again. We need to check if the call should still be picked up.

Fix for issue - https://github.com/babblevoice/babble-sip/issues/308