### PR TITLE
Bug after fail check other agents

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,6 +286,7 @@ class fifos {
       } )
     }
 
+    /* emit a stats event */
     f.stats()
   }
 

--- a/lib/fifo.js
+++ b/lib/fifo.js
@@ -628,7 +628,7 @@ class fifo {
 
     /* get next agent - the oldest by age of when we last called them */
     let agents = Object.values( this._agents ).filter( a => "available" === a.state )
-    agents = agents.sort( ( a, b ) => { return a.last - b.last } )
+                  .sort( ( a, b ) => { return a.last - b.last } )
 
     const newuac = () => {
 
@@ -667,13 +667,14 @@ class fifo {
           "confirm": this._enterpriseallconfirm.bind( this ),
           "fail": () => {
             setTimeout( () => {
-              if( "early" !== a.state ) return
-
               a.callcount--
               if( 0 > a.callcount ) a.callcount = 0
+              if( 0 === a.callcount ) {
+                a.state = "available"
+              }
 
-              if( 0 !== a.callcount ) return
-              a.state = "available"
+              agents = Object.values( this._agents ).filter( a => "available" === a.state )
+                  .sort( ( a, b ) => { return a.last - b.last } )
   
               newuac()
             }, Math.max( a.agentlag, 100 ) )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babblevoice/babble-drachtio-fifo",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@babblevoice/babble-drachtio-fifo",
-      "version": "1.11.6",
+      "version": "1.11.7",
       "license": "MIT",
       "dependencies": {
         "drachtio-srf": "^4.4.59"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babblevoice/babble-drachtio-fifo",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "A call queue (fifo)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
After a call fails, the agent may have been removed from the queue - so the failed call (possibly time-out) must re-assess the agent list before retrying - which will just go silent if no acceptable agents are left.